### PR TITLE
Update Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17-stretch AS builder
+FROM golang:1.22-bookworm AS builder
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		git gcc ca-certificates
 		


### PR DESCRIPTION
Problem when running build; it seems that stretch repos are unreachable. updating golang to use bookworm seemed to fix the problem

Here is the problematic output


 => ERROR [ 2/10] RUN apt-get update && apt-get install -y --no-install-recommends   git gcc ca-certificates                                                            1.9s
------
...
0.604 Err:7 http://deb.debian.org/debian stretch/main amd64 Packages
0.604   404  Not Found
0.626 Ign:8 http://deb.debian.org/debian stretch/main all Packages
0.637 Err:9 http://security.debian.org/debian-security stretch/updates/main amd64 Packages
0.637   404  Not Found
0.637 Err:10 http://deb.debian.org/debian stretch-updates/main amd64 Packages
0.637   404  Not Found
0.649 Ign:12 http://deb.debian.org/debian stretch-updates/main all Packages
0.649 Ign:11 http://security.debian.org/debian-security stretch/updates/main all Packages
0.652 Reading package lists...
0.662 W: The repository 'http://security.debian.org/debian-security stretch/updates Release' does not have a Release file.
0.662 W: The repository 'http://deb.debian.org/debian stretch Release' does not have a Release file.
0.662 W: The repository 'http://deb.debian.org/debian stretch-updates Release' does not have a Release file.
0.662 E: Failed to fetch http://security.debian.org/debian-security/dists/stretch/updates/main/binary-amd64/Packages  404  Not Found
0.662 E: Failed to fetch http://deb.debian.org/debian/dists/stretch/main/binary-amd64/Packages  404  Not Found
0.662 E: Failed to fetch http://deb.debian.org/debian/dists/stretch-updates/main/binary-amd64/Packages  404  Not Found
0.662 E: Some index files failed to download. They have been ignored, or old ones used instead.
------
Dockerfile:2
--------------------
   1 |     FROM golang:1.17-stretch AS builder
   2 | >>> RUN apt-get update && apt-get install -y --no-install-recommends \
   3 | >>>              git gcc ca-certificates
   4 |
--------------------
ERROR: failed to solve: process "/bin/sh -c apt-get update && apt-get install -y --no-install-recommends \t\tgit gcc ca-certificates" did not complete successfully: exit code: 100